### PR TITLE
fix: remove private visibility for border radius and edge constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,7 @@
 ## [1.1.0] - 2020-11-22
 * Add black and white colors
 * Add numeric value in font_weight docs
+
+## [1.1.1] - 2020-11-22
+* Define public constant values for border radius
+* Define public constant values for edges

--- a/lib/src/border_radius.dart
+++ b/lib/src/border_radius.dart
@@ -2,239 +2,254 @@ import 'package:flutter/material.dart';
 
 /// Defines border radius constants
 abstract class StiloBorderRadius {
-  static const _r0 = Radius.circular(0.0);
-  static const _r1 = Radius.circular(1.5);
-  static const _r2 = Radius.circular(3.0);
-  static const _r3 = Radius.circular(4.5);
-  static const _r4 = Radius.circular(6.0);
-  static const _r5 = Radius.circular(9.0);
-  static const _r6 = Radius.circular(12.0);
-  static const _r7 = Radius.circular(18.0);
+  /// Defines a circular radius of 0.0
+  static const rad0 = Radius.circular(0.0);
+
+  /// Defines a circular radius of 1.5
+  static const rad1 = Radius.circular(1.5);
+
+  /// Defines a circular radius of 3.0
+  static const rad2 = Radius.circular(3.0);
+
+  /// Defines a circular radius of 4.5
+  static const rad3 = Radius.circular(4.5);
+
+  /// Defines a circular radius of 6.0
+  static const rad4 = Radius.circular(6.0);
+
+  /// Defines a circular radius of 9.0
+  static const rad5 = Radius.circular(9.0);
+
+  /// Defines a circular radius of 12.0
+  static const rad6 = Radius.circular(12.0);
+
+  /// Defines a circular radius of 18.0
+  static const rad7 = Radius.circular(18.0);
 
   // [BorderRadiusDirectional All]
   /// Constructs a circular border radius of 0.0 for all directions
-  static const a0 = BorderRadiusDirectional.all(_r0);
+  static const a0 = BorderRadiusDirectional.all(rad0);
 
   /// Constructs a circular border radius of 1.5 for all directions
-  static const a1 = BorderRadiusDirectional.all(_r1);
+  static const a1 = BorderRadiusDirectional.all(rad1);
 
   /// Constructs a circular border radius of 3.0 for all directions
-  static const a2 = BorderRadiusDirectional.all(_r2);
+  static const a2 = BorderRadiusDirectional.all(rad2);
 
   /// Constructs a circular border radius of 4.5 for all directions
-  static const a3 = BorderRadiusDirectional.all(_r3);
+  static const a3 = BorderRadiusDirectional.all(rad3);
 
   /// Constructs a circular border radius of 6.0 for all directions
-  static const a4 = BorderRadiusDirectional.all(_r4);
+  static const a4 = BorderRadiusDirectional.all(rad4);
 
   /// Constructs a circular border radius of 9.0 for all directions
-  static const a5 = BorderRadiusDirectional.all(_r5);
+  static const a5 = BorderRadiusDirectional.all(rad5);
 
   /// Constructs a circular border radius of 12.0 for all directions
-  static const a6 = BorderRadiusDirectional.all(_r6);
+  static const a6 = BorderRadiusDirectional.all(rad6);
 
   /// Constructs a circular border radius of 18.0 for all directions
-  static const a7 = BorderRadiusDirectional.all(_r7);
+  static const a7 = BorderRadiusDirectional.all(rad7);
 
   // [BorderRadiusDirectional Top]
   /// Constructs a circular border radius of 0.0 for top direction
-  static const t0 = BorderRadiusDirectional.vertical(top: _r0);
+  static const t0 = BorderRadiusDirectional.vertical(top: rad0);
 
   /// Constructs a circular border radius of 1.5 for top direction
-  static const t1 = BorderRadiusDirectional.vertical(top: _r1);
+  static const t1 = BorderRadiusDirectional.vertical(top: rad1);
 
   /// Constructs a circular border radius of 3.0 for top direction
-  static const t2 = BorderRadiusDirectional.vertical(top: _r2);
+  static const t2 = BorderRadiusDirectional.vertical(top: rad2);
 
   /// Constructs a circular border radius of 4.5 for top direction
-  static const t3 = BorderRadiusDirectional.vertical(top: _r3);
+  static const t3 = BorderRadiusDirectional.vertical(top: rad3);
 
   /// Constructs a circular border radius of 6.0 for top direction
-  static const t4 = BorderRadiusDirectional.vertical(top: _r4);
+  static const t4 = BorderRadiusDirectional.vertical(top: rad4);
 
   /// Constructs a circular border radius of 9.0 for top direction
-  static const t5 = BorderRadiusDirectional.vertical(top: _r5);
+  static const t5 = BorderRadiusDirectional.vertical(top: rad5);
 
   /// Constructs a circular border radius of 12.0 for top direction
-  static const t6 = BorderRadiusDirectional.vertical(top: _r6);
+  static const t6 = BorderRadiusDirectional.vertical(top: rad6);
 
   /// Constructs a circular border radius of 18.0 for top direction
-  static const t7 = BorderRadiusDirectional.vertical(top: _r7);
+  static const t7 = BorderRadiusDirectional.vertical(top: rad7);
 
   // [BorderRadiusDirectional Right]
   /// Constructs a circular border radius of 0.0 for right direction
-  static const r0 = BorderRadiusDirectional.horizontal(end: _r0);
+  static const r0 = BorderRadiusDirectional.horizontal(end: rad0);
 
   /// Constructs a circular border radius of 1.5 for right direction
-  static const r1 = BorderRadiusDirectional.horizontal(end: _r1);
+  static const r1 = BorderRadiusDirectional.horizontal(end: rad1);
 
   /// Constructs a circular border radius of 3.0 for right direction
-  static const r2 = BorderRadiusDirectional.horizontal(end: _r2);
+  static const r2 = BorderRadiusDirectional.horizontal(end: rad2);
 
   /// Constructs a circular border radius of 4.5 for right direction
-  static const r3 = BorderRadiusDirectional.horizontal(end: _r3);
+  static const r3 = BorderRadiusDirectional.horizontal(end: rad3);
 
   /// Constructs a circular border radius of 6.0 for right direction
-  static const r4 = BorderRadiusDirectional.horizontal(end: _r4);
+  static const r4 = BorderRadiusDirectional.horizontal(end: rad4);
 
   /// Constructs a circular border radius of 9.0 for right direction
-  static const r5 = BorderRadiusDirectional.horizontal(end: _r5);
+  static const r5 = BorderRadiusDirectional.horizontal(end: rad5);
 
   /// Constructs a circular border radius of 12.0 for right direction
-  static const r6 = BorderRadiusDirectional.horizontal(end: _r6);
+  static const r6 = BorderRadiusDirectional.horizontal(end: rad6);
 
   /// Constructs a circular border radius of 18.0 for right direction
-  static const r7 = BorderRadiusDirectional.horizontal(end: _r7);
+  static const r7 = BorderRadiusDirectional.horizontal(end: rad7);
 
   // [BorderRadiusDirectional Bottom]
   /// Constructs a circular border radius of 0.0 for bottom direction
-  static const b0 = BorderRadiusDirectional.vertical(bottom: _r0);
+  static const b0 = BorderRadiusDirectional.vertical(bottom: rad0);
 
   /// Constructs a circular border radius of 1.5 for bottom direction
-  static const b1 = BorderRadiusDirectional.vertical(bottom: _r1);
+  static const b1 = BorderRadiusDirectional.vertical(bottom: rad1);
 
   /// Constructs a circular border radius of 3.0 for bottom direction
-  static const b2 = BorderRadiusDirectional.vertical(bottom: _r2);
+  static const b2 = BorderRadiusDirectional.vertical(bottom: rad2);
 
   /// Constructs a circular border radius of 4.5 for bottom direction
-  static const b3 = BorderRadiusDirectional.vertical(bottom: _r3);
+  static const b3 = BorderRadiusDirectional.vertical(bottom: rad3);
 
   /// Constructs a circular border radius of 6.0 for bottom direction
-  static const b4 = BorderRadiusDirectional.vertical(bottom: _r4);
+  static const b4 = BorderRadiusDirectional.vertical(bottom: rad4);
 
   /// Constructs a circular border radius of 9.0 for bottom direction
-  static const b5 = BorderRadiusDirectional.vertical(bottom: _r5);
+  static const b5 = BorderRadiusDirectional.vertical(bottom: rad5);
 
   /// Constructs a circular border radius of 12.0 for bottom direction
-  static const b6 = BorderRadiusDirectional.vertical(bottom: _r6);
+  static const b6 = BorderRadiusDirectional.vertical(bottom: rad6);
 
   /// Constructs a circular border radius of 18.0 for bottom direction
-  static const b7 = BorderRadiusDirectional.vertical(bottom: _r7);
+  static const b7 = BorderRadiusDirectional.vertical(bottom: rad7);
 
   // [BorderRadiusDirectional Left]
   /// Constructs a circular border radius of 0.0 for left direction
-  static const l0 = BorderRadiusDirectional.horizontal(start: _r0);
+  static const l0 = BorderRadiusDirectional.horizontal(start: rad0);
 
   /// Constructs a circular border radius of 1.5 for left direction
-  static const l1 = BorderRadiusDirectional.horizontal(start: _r1);
+  static const l1 = BorderRadiusDirectional.horizontal(start: rad1);
 
   /// Constructs a circular border radius of 3.0 for left direction
-  static const l2 = BorderRadiusDirectional.horizontal(start: _r2);
+  static const l2 = BorderRadiusDirectional.horizontal(start: rad2);
 
   /// Constructs a circular border radius of 4.5 for left direction
-  static const l3 = BorderRadiusDirectional.horizontal(start: _r3);
+  static const l3 = BorderRadiusDirectional.horizontal(start: rad3);
 
   /// Constructs a circular border radius of 6.0 for left direction
-  static const l4 = BorderRadiusDirectional.horizontal(start: _r4);
+  static const l4 = BorderRadiusDirectional.horizontal(start: rad4);
 
   /// Constructs a circular border radius of 9.0 for left direction
-  static const l5 = BorderRadiusDirectional.horizontal(start: _r5);
+  static const l5 = BorderRadiusDirectional.horizontal(start: rad5);
 
   /// Constructs a circular border radius of 12.0 for left direction
-  static const l6 = BorderRadiusDirectional.horizontal(start: _r6);
+  static const l6 = BorderRadiusDirectional.horizontal(start: rad6);
 
   /// Constructs a circular border radius of 18.0 for left direction
-  static const l7 = BorderRadiusDirectional.horizontal(start: _r7);
+  static const l7 = BorderRadiusDirectional.horizontal(start: rad7);
 
   // [BorderRadiusDirectional Top-Start]
   /// Constructs a circular border radius of 0.0 for top-start direction
-  static const ts0 = BorderRadiusDirectional.only(topStart: _r0);
+  static const ts0 = BorderRadiusDirectional.only(topStart: rad0);
 
   /// Constructs a circular border radius of 1.5 for top-start direction
-  static const ts1 = BorderRadiusDirectional.only(topStart: _r1);
+  static const ts1 = BorderRadiusDirectional.only(topStart: rad1);
 
   /// Constructs a circular border radius of 3.0 for top-start direction
-  static const ts2 = BorderRadiusDirectional.only(topStart: _r2);
+  static const ts2 = BorderRadiusDirectional.only(topStart: rad2);
 
   /// Constructs a circular border radius of 4.5 for top-start direction
-  static const ts3 = BorderRadiusDirectional.only(topStart: _r3);
+  static const ts3 = BorderRadiusDirectional.only(topStart: rad3);
 
   /// Constructs a circular border radius of 6.0 for top-start direction
-  static const ts4 = BorderRadiusDirectional.only(topStart: _r4);
+  static const ts4 = BorderRadiusDirectional.only(topStart: rad4);
 
   /// Constructs a circular border radius of 9.0 for top-start direction
-  static const ts5 = BorderRadiusDirectional.only(topStart: _r5);
+  static const ts5 = BorderRadiusDirectional.only(topStart: rad5);
 
   /// Constructs a circular border radius of 12.0 for top-start direction
-  static const ts6 = BorderRadiusDirectional.only(topStart: _r6);
+  static const ts6 = BorderRadiusDirectional.only(topStart: rad6);
 
   /// Constructs a circular border radius of 18.0 for top-start direction
-  static const ts7 = BorderRadiusDirectional.only(topStart: _r7);
+  static const ts7 = BorderRadiusDirectional.only(topStart: rad7);
 
   // [BorderRadiusDirectional Top-End]
   /// Constructs a circular border radius of 0.0 for top-end direction
-  static const te0 = BorderRadiusDirectional.only(topEnd: _r0);
+  static const te0 = BorderRadiusDirectional.only(topEnd: rad0);
 
   /// Constructs a circular border radius of 1.5 for top-end direction
-  static const te1 = BorderRadiusDirectional.only(topEnd: _r1);
+  static const te1 = BorderRadiusDirectional.only(topEnd: rad1);
 
   /// Constructs a circular border radius of 3.0 for top-end direction
-  static const te2 = BorderRadiusDirectional.only(topEnd: _r2);
+  static const te2 = BorderRadiusDirectional.only(topEnd: rad2);
 
   /// Constructs a circular border radius of 4.5 for top-end direction
-  static const te3 = BorderRadiusDirectional.only(topEnd: _r3);
+  static const te3 = BorderRadiusDirectional.only(topEnd: rad3);
 
   /// Constructs a circular border radius of 6.0 for top-end direction
-  static const te4 = BorderRadiusDirectional.only(topEnd: _r4);
+  static const te4 = BorderRadiusDirectional.only(topEnd: rad4);
 
   /// Constructs a circular border radius of 9.0 for top-end direction
-  static const te5 = BorderRadiusDirectional.only(topEnd: _r5);
+  static const te5 = BorderRadiusDirectional.only(topEnd: rad5);
 
   /// Constructs a circular border radius of 12.0 for top-end direction
-  static const te6 = BorderRadiusDirectional.only(topEnd: _r6);
+  static const te6 = BorderRadiusDirectional.only(topEnd: rad6);
 
   /// Constructs a circular border radius of 18.0 for top-end direction
-  static const te7 = BorderRadiusDirectional.only(topEnd: _r7);
+  static const te7 = BorderRadiusDirectional.only(topEnd: rad7);
 
   // [BorderRadiusDirectional Bottom-Start]
   /// Constructs a circular border radius of 0.0 for bottom-start direction
-  static const bs0 = BorderRadiusDirectional.only(bottomStart: _r0);
+  static const bs0 = BorderRadiusDirectional.only(bottomStart: rad0);
 
   /// Constructs a circular border radius of 1.5 for bottom-start direction
-  static const bs1 = BorderRadiusDirectional.only(bottomStart: _r1);
+  static const bs1 = BorderRadiusDirectional.only(bottomStart: rad1);
 
   /// Constructs a circular border radius of 3.0 for bottom-start direction
-  static const bs2 = BorderRadiusDirectional.only(bottomStart: _r2);
+  static const bs2 = BorderRadiusDirectional.only(bottomStart: rad2);
 
   /// Constructs a circular border radius of 4.5 for bottom-start direction
-  static const bs3 = BorderRadiusDirectional.only(bottomStart: _r3);
+  static const bs3 = BorderRadiusDirectional.only(bottomStart: rad3);
 
   /// Constructs a circular border radius of 6.0 for bottom-start direction
-  static const bs4 = BorderRadiusDirectional.only(bottomStart: _r4);
+  static const bs4 = BorderRadiusDirectional.only(bottomStart: rad4);
 
   /// Constructs a circular border radius of 9.0 for bottom-start direction
-  static const bs5 = BorderRadiusDirectional.only(bottomStart: _r5);
+  static const bs5 = BorderRadiusDirectional.only(bottomStart: rad5);
 
   /// Constructs a circular border radius of 12.0 for bottom-start direction
-  static const bs6 = BorderRadiusDirectional.only(bottomStart: _r6);
+  static const bs6 = BorderRadiusDirectional.only(bottomStart: rad6);
 
   /// Constructs a circular border radius of 18.0 for bottom-start direction
-  static const bs7 = BorderRadiusDirectional.only(bottomStart: _r7);
+  static const bs7 = BorderRadiusDirectional.only(bottomStart: rad7);
 
   // [BorderRadiusDirectional Bottom-End]
   /// Constructs a circular border radius of 0.0 for bottom-end direction
-  static const be0 = BorderRadiusDirectional.only(bottomEnd: _r0);
+  static const be0 = BorderRadiusDirectional.only(bottomEnd: rad0);
 
   /// Constructs a circular border radius of 1.5 for bottom-end direction
-  static const be1 = BorderRadiusDirectional.only(bottomEnd: _r1);
+  static const be1 = BorderRadiusDirectional.only(bottomEnd: rad1);
 
   /// Constructs a circular border radius of 3.0 for bottom-end direction
-  static const be2 = BorderRadiusDirectional.only(bottomEnd: _r2);
+  static const be2 = BorderRadiusDirectional.only(bottomEnd: rad2);
 
   /// Constructs a circular border radius of 4.5 for bottom-end direction
-  static const be3 = BorderRadiusDirectional.only(bottomEnd: _r3);
+  static const be3 = BorderRadiusDirectional.only(bottomEnd: rad3);
 
   /// Constructs a circular border radius of 6.0 for bottom-end direction
-  static const be4 = BorderRadiusDirectional.only(bottomEnd: _r4);
+  static const be4 = BorderRadiusDirectional.only(bottomEnd: rad4);
 
   /// Constructs a circular border radius of 9.0 for bottom-end direction
-  static const be5 = BorderRadiusDirectional.only(bottomEnd: _r5);
+  static const be5 = BorderRadiusDirectional.only(bottomEnd: rad5);
 
   /// Constructs a circular border radius of 12.0 for bottom-end direction
-  static const be6 = BorderRadiusDirectional.only(bottomEnd: _r6);
+  static const be6 = BorderRadiusDirectional.only(bottomEnd: rad6);
 
   /// Constructs a circular border radius of 18.0 for bottom-end direction
-  static const be7 = BorderRadiusDirectional.only(bottomEnd: _r7);
+  static const be7 = BorderRadiusDirectional.only(bottomEnd: rad7);
 
   // [BorderRadiusDirectional Shape]
   /// Constructs a circle

--- a/lib/src/edge.dart
+++ b/lib/src/edge.dart
@@ -2,275 +2,298 @@ import 'package:flutter/material.dart';
 
 /// Defines edges (margins, paddings) constants
 abstract class StiloEdge {
-  static const _e0 = 0.0;
-  static const _e1 = 3.0;
-  static const _e2 = 6.0;
-  static const _e3 = 9.0;
-  static const _e4 = 12.0;
-  static const _e5 = 15.0;
-  static const _e6 = 18.0;
-  static const _e8 = 24.0;
-  static const _e10 = 30.0;
-  static const _e12 = 36.0;
-  static const _e16 = 48.0;
-  static const _e20 = 60.0;
+  /// Defines an edge of 0.0
+  static const edge0 = 0.0;
+
+  /// Defines an edge of 3.0
+  static const edge1 = 3.0;
+
+  /// Defines an edge of 6.0
+  static const edge2 = 6.0;
+
+  /// Defines an edge of 9.0
+  static const edge3 = 9.0;
+
+  /// Defines an edge of 12.0
+  static const edge4 = 12.0;
+
+  /// Defines an edge of 15.0
+  static const edge5 = 15.0;
+
+  /// Defines an edge of 18.0
+  static const edge6 = 18.0;
+
+  /// Defines an edge of 24.0
+  static const edge8 = 24.0;
+
+  /// Defines an edge of 30.0
+  static const edge10 = 30.0;
+
+  /// Defines an edge of 36.0
+  static const edge12 = 36.0;
+
+  /// Defines an edge of 48.0
+  static const edge16 = 48.0;
+
+  /// Defines an edge of 60.0
+  static const edge20 = 60.0;
 
   // [Edge All]
   /// Constructs an edge of 0.0 for all directions
-  static const a0 = EdgeInsets.all(_e0);
+  static const a0 = EdgeInsets.all(edge0);
 
   /// Constructs an edge of 3.0 for all directions
-  static const a1 = EdgeInsets.all(_e1);
+  static const a1 = EdgeInsets.all(edge1);
 
   /// Constructs an edge of 6.0 for all directions
-  static const a2 = EdgeInsets.all(_e2);
+  static const a2 = EdgeInsets.all(edge2);
 
   /// Constructs an edge of 9.0 for all directions
-  static const a3 = EdgeInsets.all(_e3);
+  static const a3 = EdgeInsets.all(edge3);
 
   /// Constructs an edge of 12.0 for all directions
-  static const a4 = EdgeInsets.all(_e4);
+  static const a4 = EdgeInsets.all(edge4);
 
   /// Constructs an edge of 15.0 for all directions
-  static const a5 = EdgeInsets.all(_e5);
+  static const a5 = EdgeInsets.all(edge5);
 
   /// Constructs an edge of 18.0 for all directions
-  static const a6 = EdgeInsets.all(_e6);
+  static const a6 = EdgeInsets.all(edge6);
 
   /// Constructs an edge of 24.0 for all directions
-  static const a8 = EdgeInsets.all(_e8);
+  static const a8 = EdgeInsets.all(edge8);
 
   /// Constructs an edge of 30.0 for all directions
-  static const a10 = EdgeInsets.all(_e10);
+  static const a10 = EdgeInsets.all(edge10);
 
   /// Constructs an edge of 36.0 for all directions
-  static const a12 = EdgeInsets.all(_e12);
+  static const a12 = EdgeInsets.all(edge12);
 
   /// Constructs an edge of 48.0 for all directions
-  static const a16 = EdgeInsets.all(_e16);
+  static const a16 = EdgeInsets.all(edge16);
 
   /// Constructs an edge of 60.0 for all directions
-  static const a20 = EdgeInsets.all(_e20);
+  static const a20 = EdgeInsets.all(edge20);
 
   // [Edge Horizontal]
   /// Constructs an edge of 0.0 for horizontal directions
-  static const x0 = EdgeInsets.symmetric(horizontal: _e0);
+  static const x0 = EdgeInsets.symmetric(horizontal: edge0);
 
   /// Constructs an edge of 3.0 for horizontal directions
-  static const x1 = EdgeInsets.symmetric(horizontal: _e1);
+  static const x1 = EdgeInsets.symmetric(horizontal: edge1);
 
   /// Constructs an edge of 6.0 for horizontal directions
-  static const x2 = EdgeInsets.symmetric(horizontal: _e2);
+  static const x2 = EdgeInsets.symmetric(horizontal: edge2);
 
   /// Constructs an edge of 9.0 for horizontal directions
-  static const x3 = EdgeInsets.symmetric(horizontal: _e3);
+  static const x3 = EdgeInsets.symmetric(horizontal: edge3);
 
   /// Constructs an edge of 12.0 for horizontal directions
-  static const x4 = EdgeInsets.symmetric(horizontal: _e4);
+  static const x4 = EdgeInsets.symmetric(horizontal: edge4);
 
   /// Constructs an edge of 15.0 for horizontal directions
-  static const x5 = EdgeInsets.symmetric(horizontal: _e5);
+  static const x5 = EdgeInsets.symmetric(horizontal: edge5);
 
   /// Constructs an edge of 18.0 for horizontal directions
-  static const x6 = EdgeInsets.symmetric(horizontal: _e6);
+  static const x6 = EdgeInsets.symmetric(horizontal: edge6);
 
   /// Constructs an edge of 24.0 for horizontal directions
-  static const x8 = EdgeInsets.symmetric(horizontal: _e8);
+  static const x8 = EdgeInsets.symmetric(horizontal: edge8);
 
   /// Constructs an edge of 30.0 for horizontal directions
-  static const x10 = EdgeInsets.symmetric(horizontal: _e10);
+  static const x10 = EdgeInsets.symmetric(horizontal: edge10);
 
   /// Constructs an edge of 36.0 for horizontal directions
-  static const x12 = EdgeInsets.symmetric(horizontal: _e12);
+  static const x12 = EdgeInsets.symmetric(horizontal: edge12);
 
   /// Constructs an edge of 48.0 for horizontal directions
-  static const x16 = EdgeInsets.symmetric(horizontal: _e16);
+  static const x16 = EdgeInsets.symmetric(horizontal: edge16);
 
   /// Constructs an edge of 60.0 for horizontal directions
-  static const x20 = EdgeInsets.symmetric(horizontal: _e20);
+  static const x20 = EdgeInsets.symmetric(horizontal: edge20);
 
   // [Edge Vertical]
   /// Constructs an edge of 0.0 for vertical directions
-  static const y0 = EdgeInsets.symmetric(vertical: _e0);
+  static const y0 = EdgeInsets.symmetric(vertical: edge0);
 
   /// Constructs an edge of 3.0 for vertical directions
-  static const y1 = EdgeInsets.symmetric(vertical: _e1);
+  static const y1 = EdgeInsets.symmetric(vertical: edge1);
 
   /// Constructs an edge of 6.0 for vertical directions
-  static const y2 = EdgeInsets.symmetric(vertical: _e2);
+  static const y2 = EdgeInsets.symmetric(vertical: edge2);
 
   /// Constructs an edge of 9.0 for vertical directions
-  static const y3 = EdgeInsets.symmetric(vertical: _e3);
+  static const y3 = EdgeInsets.symmetric(vertical: edge3);
 
   /// Constructs an edge of 12.0 for vertical directions
-  static const y4 = EdgeInsets.symmetric(vertical: _e4);
+  static const y4 = EdgeInsets.symmetric(vertical: edge4);
 
   /// Constructs an edge of 15.0 for vertical directions
-  static const y5 = EdgeInsets.symmetric(vertical: _e5);
+  static const y5 = EdgeInsets.symmetric(vertical: edge5);
 
   /// Constructs an edge of 18.0 for vertical directions
-  static const y6 = EdgeInsets.symmetric(vertical: _e6);
+  static const y6 = EdgeInsets.symmetric(vertical: edge6);
 
   /// Constructs an edge of 24.0 for vertical directions
-  static const y8 = EdgeInsets.symmetric(vertical: _e8);
+  static const y8 = EdgeInsets.symmetric(vertical: edge8);
 
   /// Constructs an edge of 30.0 for vertical directions
-  static const y10 = EdgeInsets.symmetric(vertical: _e10);
+  static const y10 = EdgeInsets.symmetric(vertical: edge10);
 
   /// Constructs an edge of 36.0 for vertical directions
-  static const y12 = EdgeInsets.symmetric(vertical: _e12);
+  static const y12 = EdgeInsets.symmetric(vertical: edge12);
 
   /// Constructs an edge of 48.0 for vertical directions
-  static const y16 = EdgeInsets.symmetric(vertical: _e16);
+  static const y16 = EdgeInsets.symmetric(vertical: edge16);
 
   /// Constructs an edge of 60.0 for vertical directions
-  static const y20 = EdgeInsets.symmetric(vertical: _e20);
+  static const y20 = EdgeInsets.symmetric(vertical: edge20);
 
   // [Edge Top]
   /// Constructs an edge of 0.0 for top direction
-  static const t0 = EdgeInsets.only(top: _e0);
+  static const t0 = EdgeInsets.only(top: edge0);
 
   /// Constructs an edge of 3.0 for top direction
-  static const t1 = EdgeInsets.only(top: _e1);
+  static const t1 = EdgeInsets.only(top: edge1);
 
   /// Constructs an edge of 6.0 for top direction
-  static const t2 = EdgeInsets.only(top: _e2);
+  static const t2 = EdgeInsets.only(top: edge2);
 
   /// Constructs an edge of 9.0 for top direction
-  static const t3 = EdgeInsets.only(top: _e3);
+  static const t3 = EdgeInsets.only(top: edge3);
 
   /// Constructs an edge of 12.0 for top direction
-  static const t4 = EdgeInsets.only(top: _e4);
+  static const t4 = EdgeInsets.only(top: edge4);
 
   /// Constructs an edge of 15.0 for top direction
-  static const t5 = EdgeInsets.only(top: _e5);
+  static const t5 = EdgeInsets.only(top: edge5);
 
   /// Constructs an edge of 18.0 for top direction
-  static const t6 = EdgeInsets.only(top: _e6);
+  static const t6 = EdgeInsets.only(top: edge6);
 
   /// Constructs an edge of 24.0 for top direction
-  static const t8 = EdgeInsets.only(top: _e8);
+  static const t8 = EdgeInsets.only(top: edge8);
 
   /// Constructs an edge of 30.0 for top direction
-  static const t10 = EdgeInsets.only(top: _e10);
+  static const t10 = EdgeInsets.only(top: edge10);
 
   /// Constructs an edge of 36.0 for top direction
-  static const t12 = EdgeInsets.only(top: _e12);
+  static const t12 = EdgeInsets.only(top: edge12);
 
   /// Constructs an edge of 48.0 for top direction
-  static const t16 = EdgeInsets.only(top: _e16);
+  static const t16 = EdgeInsets.only(top: edge16);
 
   /// Constructs an edge of 60.0 for top direction
-  static const t20 = EdgeInsets.only(top: _e20);
+  static const t20 = EdgeInsets.only(top: edge20);
 
   // [Edge Right]
   /// Constructs an edge of 0.0 for right direction
-  static const r0 = EdgeInsets.only(right: _e0);
+  static const r0 = EdgeInsets.only(right: edge0);
 
   /// Constructs an edge of 3.0 for right direction
-  static const r1 = EdgeInsets.only(right: _e1);
+  static const r1 = EdgeInsets.only(right: edge1);
 
   /// Constructs an edge of 6.0 for right direction
-  static const r2 = EdgeInsets.only(right: _e2);
+  static const r2 = EdgeInsets.only(right: edge2);
 
   /// Constructs an edge of 9.0 for right direction
-  static const r3 = EdgeInsets.only(right: _e3);
+  static const r3 = EdgeInsets.only(right: edge3);
 
   /// Constructs an edge of 12.0 for right direction
-  static const r4 = EdgeInsets.only(right: _e4);
+  static const r4 = EdgeInsets.only(right: edge4);
 
   /// Constructs an edge of 15.0 for right direction
-  static const r5 = EdgeInsets.only(right: _e5);
+  static const r5 = EdgeInsets.only(right: edge5);
 
   /// Constructs an edge of 18.0 for right direction
-  static const r6 = EdgeInsets.only(right: _e6);
+  static const r6 = EdgeInsets.only(right: edge6);
 
   /// Constructs an edge of 24.0 for right direction
-  static const r8 = EdgeInsets.only(right: _e8);
+  static const r8 = EdgeInsets.only(right: edge8);
 
   /// Constructs an edge of 30.0 for right direction
-  static const r10 = EdgeInsets.only(right: _e10);
+  static const r10 = EdgeInsets.only(right: edge10);
 
   /// Constructs an edge of 36.0 for right direction
-  static const r12 = EdgeInsets.only(right: _e12);
+  static const r12 = EdgeInsets.only(right: edge12);
 
   /// Constructs an edge of 48.0 for right direction
-  static const r16 = EdgeInsets.only(right: _e16);
+  static const r16 = EdgeInsets.only(right: edge16);
 
   /// Constructs an edge of 60.0 for right direction
-  static const r20 = EdgeInsets.only(right: _e20);
+  static const r20 = EdgeInsets.only(right: edge20);
 
   // [Edge Bottom]
   /// Constructs an edge of 0.0 for bottom direction
-  static const b0 = EdgeInsets.only(bottom: _e0);
+  static const b0 = EdgeInsets.only(bottom: edge0);
 
   /// Constructs an edge of 3.0 for bottom direction
-  static const b1 = EdgeInsets.only(bottom: _e1);
+  static const b1 = EdgeInsets.only(bottom: edge1);
 
   /// Constructs an edge of 6.0 for bottom direction
-  static const b2 = EdgeInsets.only(bottom: _e2);
+  static const b2 = EdgeInsets.only(bottom: edge2);
 
   /// Constructs an edge of 9.0 for bottom direction
-  static const b3 = EdgeInsets.only(bottom: _e3);
+  static const b3 = EdgeInsets.only(bottom: edge3);
 
   /// Constructs an edge of 12.0 for bottom direction
-  static const b4 = EdgeInsets.only(bottom: _e4);
+  static const b4 = EdgeInsets.only(bottom: edge4);
 
   /// Constructs an edge of 15.0 for bottom direction
-  static const b5 = EdgeInsets.only(bottom: _e5);
+  static const b5 = EdgeInsets.only(bottom: edge5);
 
   /// Constructs an edge of 18.0 for bottom direction
-  static const b6 = EdgeInsets.only(bottom: _e6);
+  static const b6 = EdgeInsets.only(bottom: edge6);
 
   /// Constructs an edge of 24.0 for bottom direction
-  static const b8 = EdgeInsets.only(bottom: _e8);
+  static const b8 = EdgeInsets.only(bottom: edge8);
 
   /// Constructs an edge of 30.0 for bottom direction
-  static const b10 = EdgeInsets.only(bottom: _e10);
+  static const b10 = EdgeInsets.only(bottom: edge10);
 
   /// Constructs an edge of 36.0 for bottom direction
-  static const b12 = EdgeInsets.only(bottom: _e12);
+  static const b12 = EdgeInsets.only(bottom: edge12);
 
   /// Constructs an edge of 48.0 for bottom direction
-  static const b16 = EdgeInsets.only(bottom: _e16);
+  static const b16 = EdgeInsets.only(bottom: edge16);
 
   /// Constructs an edge of 60.0 for bottom direction
-  static const b20 = EdgeInsets.only(bottom: _e20);
+  static const b20 = EdgeInsets.only(bottom: edge20);
 
   // [Edge Left]
   /// Constructs an edge of 0.0 for left direction
-  static const l0 = EdgeInsets.only(left: _e0);
+  static const l0 = EdgeInsets.only(left: edge0);
 
   /// Constructs an edge of 3.0 for left direction
-  static const l1 = EdgeInsets.only(left: _e1);
+  static const l1 = EdgeInsets.only(left: edge1);
 
   /// Constructs an edge of 6.0 for left direction
-  static const l2 = EdgeInsets.only(left: _e2);
+  static const l2 = EdgeInsets.only(left: edge2);
 
   /// Constructs an edge of 9.0 for left direction
-  static const l3 = EdgeInsets.only(left: _e3);
+  static const l3 = EdgeInsets.only(left: edge3);
 
   /// Constructs an edge of 12.0 for left direction
-  static const l4 = EdgeInsets.only(left: _e4);
+  static const l4 = EdgeInsets.only(left: edge4);
 
   /// Constructs an edge of 15.0 for left direction
-  static const l5 = EdgeInsets.only(left: _e5);
+  static const l5 = EdgeInsets.only(left: edge5);
 
   /// Constructs an edge of 18.0 for left direction
-  static const l6 = EdgeInsets.only(left: _e6);
+  static const l6 = EdgeInsets.only(left: edge6);
 
   /// Constructs an edge of 24.0 for left direction
-  static const l8 = EdgeInsets.only(left: _e8);
+  static const l8 = EdgeInsets.only(left: edge8);
 
   /// Constructs an edge of 30.0 for left direction
-  static const l10 = EdgeInsets.only(left: _e10);
+  static const l10 = EdgeInsets.only(left: edge10);
 
   /// Constructs an edge of 36.0 for left direction
-  static const l12 = EdgeInsets.only(left: _e12);
+  static const l12 = EdgeInsets.only(left: edge12);
 
   /// Constructs an edge of 48.0 for left direction
-  static const l16 = EdgeInsets.only(left: _e16);
+  static const l16 = EdgeInsets.only(left: edge16);
 
   /// Constructs an edge of 60.0 for left direction
-  static const l20 = EdgeInsets.only(left: _e20);
+  static const l20 = EdgeInsets.only(left: edge20);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stilo
 description: Stilo is a utility-first Flutter framework that gives you all of the building constants you need to build designs without define common styles for spacing, borders and much more
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/mirkorap/stilo
 
 environment:


### PR DESCRIPTION
# What does this change?
Remove private visibility for border radius and edge constants

# Why this change is important?
Because allows to use costant numeric value to defines custom paddings and border radius