### PR TITLE
bugfix: duration constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@
 ## [1.1.1] - 2020-11-22
 * Define public constant values for border radius
 * Define public constant values for edges
+
+## [1.1.2] - 2021-02-07
+* Fix durations types. Replace microseconds with milliseconds
+* Add new durations types

--- a/lib/src/duration.dart
+++ b/lib/src/duration.dart
@@ -1,38 +1,38 @@
 /// Defines duration constants
 abstract class StiloDuration {
   /// Constructs a duration of 75ms
-  static const d75 = Duration(microseconds: 75);
+  static const d75 = Duration(milliseconds: 75);
 
   /// Constructs a duration of 100ms
-  static const d100 = Duration(microseconds: 100);
+  static const d100 = Duration(milliseconds: 100);
 
   /// Constructs a duration of 150ms
-  static const d150 = Duration(microseconds: 150);
+  static const d150 = Duration(milliseconds: 150);
 
   /// Constructs a duration of 200ms
-  static const d200 = Duration(microseconds: 200);
+  static const d200 = Duration(milliseconds: 200);
 
   /// Constructs a duration of 300ms
-  static const d300 = Duration(microseconds: 300);
+  static const d300 = Duration(milliseconds: 300);
 
   /// Constructs a duration of 500ms
-  static const d500 = Duration(microseconds: 500);
+  static const d500 = Duration(milliseconds: 500);
 
   /// Constructs a duration of 700ms
-  static const d700 = Duration(microseconds: 700);
+  static const d700 = Duration(milliseconds: 700);
 
   /// Constructs a duration of 1000ms
-  static const d1000 = Duration(microseconds: 1000);
+  static const d1000 = Duration(milliseconds: 1000);
 
   /// Constructs a duration of 1200ms
-  static const d1200 = Duration(microseconds: 1200);
+  static const d1200 = Duration(milliseconds: 1200);
 
   /// Constructs a duration of 1500ms
-  static const d1500 = Duration(microseconds: 1500);
+  static const d1500 = Duration(milliseconds: 1500);
 
   /// Constructs a duration of 2000ms
-  static const d2000 = Duration(microseconds: 2000);
+  static const d2000 = Duration(milliseconds: 2000);
 
   /// Constructs a duration of 3000ms
-  static const d3000 = Duration(microseconds: 3000);
+  static const d3000 = Duration(milliseconds: 3000);
 }

--- a/lib/src/duration.dart
+++ b/lib/src/duration.dart
@@ -35,4 +35,10 @@ abstract class StiloDuration {
 
   /// Constructs a duration of 3000ms
   static const d3000 = Duration(milliseconds: 3000);
+
+  /// Constructs a duration of 5000ms
+  static const d5000 = Duration(milliseconds: 5000);
+
+  /// Constructs a duration of 10000ms
+  static const d10000 = Duration(milliseconds: 10000);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stilo
 description: Stilo is a utility-first Flutter framework that gives you all of the building constants you need to build designs without define common styles for spacing, borders and much more
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/mirkorap/stilo
 
 environment:


### PR DESCRIPTION
# What does this change?
Replaces microseconds with milliseconds and adds two new durations types: _**d5000**_ and _**d10000**_